### PR TITLE
fixes #1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,8 @@ sudo apt-get install --no-install-recommends -y -q \
                      build-essential \
                      ca-certificates \
                      git mercurial bzr \
+                     libseccomp2 \
+                     libseccomp-dev
 
 GOVERSION=1.4.2
 echo "Install Go v${GOVERSION}"


### PR DESCRIPTION
Add libsecomp which will allow runc to compile successfully. I think libseccomp dependency was added during this commit: opencontainers/runc@2ae581a 
